### PR TITLE
Call Log Phone Tint [Squashed]

### DIFF
--- a/res/layout/call_log_list_item.xml
+++ b/res/layout/call_log_list_item.xml
@@ -142,7 +142,6 @@
                 android:layout_marginEnd="@dimen/call_log_icon_margin"
                 android:src="@drawable/ic_card_phone"
                 android:tint="@color/recent_call_log_item_phone_icon_tint"
-                android:alpha="0.3"
                 android:importantForAccessibility="no"
                 android:visibility="gone"
                 />

--- a/res/layout/call_log_list_item_extra.xml
+++ b/res/layout/call_log_list_item_extra.xml
@@ -58,7 +58,6 @@
             android:layout_marginEnd="@dimen/call_log_icon_margin"
             android:src="@drawable/ic_close_dk"
             android:tint="@color/recent_call_log_item_phone_icon_tint"
-            android:alpha="0.3"
             android:background="?android:attr/selectableItemBackground"
             android:visibility="gone"
             android:contentDescription="@string/description_dismiss" />

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -32,7 +32,7 @@
     <color name="call_log_voicemail_highlight_color">#33b5e5</color>
 
     <!-- Tint of the recent card phone icon -->
-    <color name="recent_call_log_item_phone_icon_tint">#000000</color>
+    <color name="recent_call_log_item_phone_icon_tint">#30000000</color>
     <color name="call_log_extras_text_color">#0277bd</color>
 
     <!--


### PR DESCRIPTION
* Removed tint from phone icon on most recent call log so it could be a solid color.
* Added "30" to keep tint still active for stock theme purposes..