### PR TITLE
Layers 2.1 (backwards compatible)

### DIFF
--- a/res/drawable/floating_action_button.xml
+++ b/res/drawable/floating_action_button.xml
@@ -19,7 +19,7 @@
     android:color="@color/floating_action_button_touch_tint">
     <item android:id="@android:id/mask">
         <shape android:shape="oval">
-            <solid android:color="@android:color/white" />
+            <solid android:color="@color/floating_action_button_color" />
         </shape>
     </item>
 </ripple>

--- a/res/drawable/tab_speed_dial.xml
+++ b/res/drawable/tab_speed_dial.xml
@@ -24,7 +24,7 @@
     </item>
 
     <item android:id="@android:id/mask">
-        <color android:color="@android:color/white" />
+        <color android:color="@color/recents_list_footer_bg" />
     </item>
 
 </ripple>

--- a/res/layout/dialpad_fragment.xml
+++ b/res/layout/dialpad_fragment.xml
@@ -30,7 +30,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:background="#00000000" />
+            android:background="@color/background_color_transparent" />
         <!-- Dialpad shadow -->
         <View
             android:layout_width="match_parent"

--- a/res/layout/keyguard_preview.xml
+++ b/res/layout/keyguard_preview.xml
@@ -26,5 +26,5 @@
         android:layout_width="match_parent"
         android:layout_weight="1"
         android:layout_height="0dp"
-        android:background="#ffffff" />
+        android:background="@color/keyguard_preview_bg" />
 </LinearLayout>

--- a/res/values/custom_colors.xml
+++ b/res/values/custom_colors.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2007 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources>
+    <color name="floating_action_button_color">@color/exposed_floating_action_button_solid</color>
+    <color name="recents_list_footer_bg">@color/exposed_recents_list_footer_bg</color>
+    <color name="background_color_black">@color/exposed_bg_light</color>
+    <color name="call_log_divider_color">#55ffffff</color>
+    <color name="background_color_transparent">@color/exposed_dialpad_fragment</color>
+    <color name="keyguard_preview_bg">@color/exposed_bg_dark</color>
+    <color name="call_log_primary_background_color">@color/exposed_bg_light</color>
+    <color name="call_log_secondary_background_color">@color/exposed_secondary_bg_color</color>
+    <color name="call_log_header_color">@color/exposed_call_log_header</color>
+    <color name="call_log_voicemail_status_background_color">
+        @color/exposed_call_log_voicemail_status_background
+    </color>
+    <color name="call_log_voicemail_status_text_color">
+        @color/exposed_call_log_voicemail_status_text
+    </color>
+    <color name="call_log_voicemail_status_action_text_color">
+        @color/exposed_call_log_voicemail_status_action_text
+    </color>
+    <color name="call_log_primary_bg_color">@color/exposed_bg_dark</color>
+    <color name="call_log_secondary_bg_color">@color/exposed_bg_dark</color>
+    <color name="call_log_header_color_dark">@color/exposed_bg_dark</color>
+    <color name="dialpad_text_color">@color/exposed_primary_text_dark</color>
+</resources> 

--- a/res/values/layers_colors.xml
+++ b/res/values/layers_colors.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2007 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources>
+    <!-- Exposed resources for theming -->
+    <color name="exposed_bg_dark">#ffffffff</color>
+    <color name="exposed_bg_light">@android:color/black</color>
+    <color name="exposed_primary_text_dark">#ffffffff</color>
+    <color name="exposed_secondary_bg_color">#333333</color>
+    <color name="exposed_call_log_header">#33b5e5</color>
+    <color name="exposed_call_log_voicemail_status_background">#262626</color>
+    <color name="exposed_call_log_voicemail_status_text">#888888</color>
+    <color name="exposed_call_log_voicemail_status_action_text">#33b5e5</color>
+    <color name="exposed_floating_action_button_solid">@android:color/white</color>
+    <color name="exposed_recents_list_footer_bg">@android:color/white</color>
+    <color name="exposed_dialpad_fragment">#00000000</color>
+</resources> 

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -15,19 +15,26 @@
   ~ limitations under the License
   -->
 <resources>
-    <style name="DialtactsTheme"
+    <style name="DialtactsTheme1"
            parent="android:Theme.Material.Light">
         <item name="android:textColorPrimary">@color/dialtacts_primary_text_color</item>
         <item name="android:textColorSecondary">@color/dialtacts_secondary_text_color</item>
+        <item name="android:actionBarStyle">@style/DialtactsActionBarStyle</item>
+        <item name="android:listViewStyle">@style/ListViewStyle</item>
+        <item name="android:colorPrimary">@color/dialer_theme_color</item>
+        <item name="android:colorPrimaryDark">@color/dialer_theme_color_dark</item>
+        <item name="android:colorControlActivated">@color/dialtacts_theme_color</item>
+    </style>
+
+    <style name="DialtactsTheme"
+           parent="@style/DialtactsTheme1">
         <item name="android:windowActionBarOverlay">true</item>
         <item name="android:windowActionModeOverlay">true</item>
-        <item name="android:actionBarStyle">@style/DialtactsActionBarStyle</item>
         <!-- Style for the overflow button in the actionbar. -->
         <item name="android:actionOverflowButtonStyle">@style/DialtactsActionBarOverflow</item>
         <!--  Drawable for the back button -->
         <item name="android:homeAsUpIndicator">@drawable/ic_back_arrow</item>
         <item name="android:windowContentOverlay">@null</item>
-        <item name="android:listViewStyle">@style/ListViewStyle</item>
         <item name="android:overlapAnchor">true</item>
         <item name="android:alertDialogTheme">@style/AlertDialogTheme</item>
         <item name="activated_background">@drawable/list_item_activated_background</item>
@@ -62,21 +69,24 @@
         <item name="list_item_text_offset_top">-2dp</item>
         <!-- CallLog -->
         <item name="call_log_primary_text_color">@color/dialtacts_primary_text_color</item>
-        <item name="call_log_primary_background_color">#000000</item>
+        <item name="call_log_primary_background_color">@color/call_log_primary_background_color</item>
         <item name="call_log_secondary_text_color">@color/dialtacts_secondary_text_color</item>
-        <item name="call_log_secondary_background_color">#333333</item>
-        <item name="call_log_header_color">#33b5e5</item>
+        <item name="call_log_secondary_background_color">@color/call_log_secondary_background_color</item>
+        <item name="call_log_header_color">@color/call_log_header_color</item>
         <!-- VoicemailStatus -->
         <item name="call_log_voicemail_status_height">48dip</item>
-        <item name="call_log_voicemail_status_background_color">#262626</item>
-        <item name="call_log_voicemail_status_text_color">#888888</item>
-        <item name="call_log_voicemail_status_action_text_color">#33b5e5</item>
+        <item name="call_log_voicemail_status_background_color">
+            @color/call_log_voicemail_status_background_color
+        </item>
+        <item name="call_log_voicemail_status_text_color">
+            @color/call_log_voicemail_status_text_color
+        </item>
+        <item name="call_log_voicemail_status_action_text_color">
+            @color/call_log_voicemail_status_action_text_color
+        </item>
             <!-- Favorites -->
         <item name="favorites_padding_bottom">?android:attr/actionBarSize</item>
-        <item name="android:colorPrimary">@color/dialer_theme_color</item>
-        <item name="android:colorPrimaryDark">@color/dialer_theme_color_dark</item>
         <item name="dialpad_key_button_touch_tint">@color/dialer_dialpad_touch_tint</item>
-        <item name="android:colorControlActivated">@color/dialer_theme_color</item>
     </style>
 
     <!-- Action bar overflow menu icon. -->
@@ -92,7 +102,7 @@
     </style>
 
     <style name="DialpadTheme" parent="DialtactsTheme">
-        <item name="android:textColorPrimary">#FFFFFF</item>
+        <item name="android:textColorPrimary">@color/dialpad_text_color</item>
     </style>
 
     <style name="DialtactsThemeWithoutActionBarOverlay" parent="DialtactsTheme">
@@ -110,14 +120,18 @@
     <style name="CallDetailActivityTheme" parent="DialtactsThemeWithoutActionBarOverlay">
         <item name="android:windowBackground">@color/background_dialer_results</item>
         <!-- CallLog -->
-        <item name="call_log_primary_background_color">#FFFFFF</item>
-        <item name="call_log_secondary_background_color">#FFFFFF</item>
-        <item name="call_log_header_color">#FFFFFF</item>
+        <item name="call_log_primary_background_color">@color/call_log_primary_bg_color</item>
+        <item name="call_log_secondary_background_color">@color/call_log_secondary_bg_color</item>
+        <item name="call_log_header_color">@color/call_log_header_color_dark</item>
         <!-- VoicemailStatus -->
         <item name="call_log_voicemail_status_height">48dip</item>
-        <item name="call_log_voicemail_status_background_color">#262626</item>
-        <item name="call_log_voicemail_status_text_color">#888888</item>
-        <item name="call_log_voicemail_status_action_text_color">#33b5e5</item>
+        <item name="call_log_voicemail_status_background_color">
+            @color/call_log_voicemail_status_background_color
+        </item>
+        <item name="call_log_voicemail_status_text_color">@color/call_log_voicemail_status_text_color</item>
+        <item name="call_log_voicemail_status_action_text_color">
+            @color/call_log_voicemail_status_action_text_color
+        </item>
         <item name="android:actionOverflowButtonStyle">@style/DialtactsActionBarOverflowWhite</item>
     </style>
 
@@ -199,6 +213,7 @@
         <!-- Setting description. -->
         <item name="android:textColorSecondary">@color/settings_text_color_secondary</item>
         <item name="android:windowBackground">@color/setting_background_color</item>
+        <item name="android:colorControlActivated">@color/dialtacts_theme_color</item>
         <item name="android:colorAccent">@color/dialtacts_theme_color</item>
         <item name="android:textColorLink">@color/dialtacts_theme_color</item>
     </style>


### PR DESCRIPTION
This is a rework of the initial layers type 2 commit:

Layers : Exposing hard coded resources for type 2 overlay access [5/6]
Author: bgill55
https://github.com/BitSyko/platform_packages_apps_Dialer/commit/6b21de366843ad8f654fed972870ce50c663ae68

Layers : Let's split styles.xml in order to make it easier to theme.
Author: CallMeAldy
https://github.com/BitSyko/platform_packages_apps_Dialer/commit/a1583bb3bf876ebea21b6ee19b5d285bf5347575

Layers : Set switch to call the theme color instead of the primary color
Author: CallMeAldy
https://github.com/BitSyko/platform_packages_apps_Dialer/commit/98cae3b841860d15e3ffd22900051f0fa08f9e8b

Make colors backwards compatible with layers previous commits based on:
Author: Andrew Dodd
https://gerrit.omnirom.org/#/c/12695/

Change-Id: Ib79cd9677ebecec3d5500cbe42b2bc0786f37a14
